### PR TITLE
Fix for the problem described on Issue 4

### DIFF
--- a/jquery.bootstrap.wizard.js
+++ b/jquery.bootstrap.wizard.js
@@ -169,7 +169,9 @@ var bootstrapWizardCreate = function(element, options) {
 	obj.fixNavigationButtons();
 
 	$('a[data-toggle="tab"]', element).on('click', function (e) {
-		if($settings.onTabClick && typeof $settings.onTabClick === 'function' && $settings.onTabClick($activeTab, $navigation, obj.currentIndex())===false){
+		// Get the index of the clicked tab
+		var clickedIndex = $navigation.find('li').index($(e.currentTarget).parent('li'));
+		if($settings.onTabClick && typeof $settings.onTabClick === 'function' && $settings.onTabClick($activeTab, $navigation, obj.currentIndex(), clickedIndex)===false){
 			return false;
 		}
 	});


### PR DESCRIPTION
Fix for #4

Added the index of the clicked tab to the 'onTabClick' event. To get in that point what is the clicked tab (before that we only know about the actual tab)
