### PR TITLE
Only look for direct children

### DIFF
--- a/jquery.bootstrap.wizard.js
+++ b/jquery.bootstrap.wizard.js
@@ -168,7 +168,7 @@ var bootstrapWizardCreate = function(element, options) {
 		$item.remove();
 	};
 
-	$navigation = element.find('ul:first', element);
+	$navigation = element.find('> ul:first', element);
 	$activeTab = $navigation.find('li.active', element);
 
 	if(!$navigation.hasClass($settings.tabClass)) {
@@ -194,7 +194,7 @@ var bootstrapWizardCreate = function(element, options) {
 	// Work the next/previous buttons
 	obj.fixNavigationButtons();
 
-	$('a[data-toggle="tab"]', element).on('click', function (e) {
+	$('a[data-toggle="tab"]', $navigation).on('click', function (e) {
 		// Get the index of the clicked tab
 		var clickedIndex = $navigation.find('li').index($(e.currentTarget).parent('li'));
 		if($settings.onTabClick && typeof $settings.onTabClick === 'function' && $settings.onTabClick($activeTab, $navigation, obj.currentIndex(), clickedIndex)===false){
@@ -202,7 +202,7 @@ var bootstrapWizardCreate = function(element, options) {
 		}
 	});
 
-	$('a[data-toggle="tab"]', element).on('show', function (e) {
+	$('a[data-toggle="tab"]', $navigation).on('show', function (e) {
 		$element = $(e.target).parent();
 		// If it's disabled then do not change
 		if($element.hasClass('disabled')) {


### PR DESCRIPTION
By only checking for `<ul>`s that are a direct child of the root wizard element (and only tabs that are part of that navigation) we're able to nest a second tab group within the main `#rootwizard` div.

This may or may not fix nested wizards, I haven't tested that. However it _does_ fix [the scenario](https://github.com/VinceG/twitter-bootstrap-wizard/issues/11#issuecomment-16353032) I commented about in issue #11.

Like I mentioned in my comment on that issue I'm not entirely sure how closely related a "wizard" is to a "vanilla" bootstrap tab group (at least when it comes to nesting them), but this could well do the trick.
