### PR TITLE
Allow wizard to skip disabled steps

### DIFF
--- a/jquery.bootstrap.wizard.js
+++ b/jquery.bootstrap.wizard.js
@@ -38,15 +38,16 @@
             };
 
             this.next = function (e) {
-                // Did we click the last button
+                // Get the next index here...
                 $index = obj.nextIndex();
+		// Get the parent class of the navigation element and store it here.
             	var navigationElementParent = $navigation.find('li:eq(' + $index + ') a').parent();
+		// Check to see if the next step is disabled, if so, skip to the next one.
             	if (navigationElementParent.hasClass('disabled') && $settings.skipDisabled == true) $index++;
                 // If we clicked the last then dont activate this
                 if (element.hasClass('last')) {
                     return false;
                 }
-
                 if ($settings.onNext && typeof $settings.onNext === 'function') {
                 	if ($settings.onNext($activeTab, $navigation, $index) === false) return false;
                	}
@@ -56,8 +57,11 @@
             };
 
             this.previous = function (e) {
-				$index = obj.previousIndex();
+		// Get previous index here...
+		$index = obj.previousIndex();
+		// Get the parent class of the navigation element and store it here.
             	var navigationElementParent = $navigation.find('li:eq(' + $index + ') a').parent();
+		// Check to see if the previous step is disabled, if so, skip to the one before that.
             	if (navigationElementParent.hasClass('disabled') && $settings.skipDisabled == true) $index--;
                 // If we clicked the first then dont activate this
                 if (element.hasClass('first')) {


### PR DESCRIPTION
Hi Vince, 

By using the master of your bootstrap wizard I was unable to allow the wizard to skip past disabled steps, so I wrote this patch :)

Hope you find it useful!

Cheers

Ps: the screen shot below shows what I mean - in this example, 'Fee details' will be skipped out.

![screen shot 2013-06-25 at 09 56 37](https://f.cloud.github.com/assets/1872162/701465/b2027ce2-dd75-11e2-9ed8-a5c5b0ed0e07.png)
