### PR TITLE
Made compatible with both bootstrap 2.3.2 and 3.0.0

### DIFF
--- a/jquery.bootstrap.wizard.js
+++ b/jquery.bootstrap.wizard.js
@@ -197,7 +197,8 @@ var bootstrapWizardCreate = function(element, options) {
 		}
 	});
 
-	$('a[data-toggle="tab"]', $navigation).on('shown', function (e) {  // use shown instead of show to help prevent double firing
+	// attach to both shown and shown.bs.tab to support Bootstrap versions 2.3.2 and 3.0.0
+	$('a[data-toggle="tab"]', $navigation).on('shown shown.bs.tab', function (e) {  // use shown instead of show to help prevent double firing
 		$element = $(e.target).parent();
 		var nextTab = $navigation.find('li').index($element);
 


### PR DESCRIPTION
Attached to both the legacy 'shown' event and new 'shown.bs.tab'.
Since only one or the other should exist. There should be no conflict.
