### PR TITLE
Added support for non-tab LI elements

### DIFF
--- a/jquery.bootstrap.wizard.js
+++ b/jquery.bootstrap.wizard.js
@@ -12,6 +12,9 @@
 var bootstrapWizardCreate = function(element, options) {
 	var element = $(element);
 	var obj = this;
+	
+	// selector skips any 'li' elements that do not contain a child with a tab data-toggle
+	var baseItemSelector = 'li:has([data-toggle="tab"])';
 
 	// Merge options with defaults
 	var $settings = $.extend({}, $.fn.bootstrapWizard.defaults, options);
@@ -28,7 +31,7 @@ var bootstrapWizardCreate = function(element, options) {
 		if(!$activeTab.length) {
 			// Select first one
 			$navigation.find('a:first').tab('show');
-			$activeTab = $navigation.find('li:first');
+			$activeTab = $navigation.find(baseItemSelector + ':first');
 		}
 
 		// See if we're currently in the first/last then disable the previous and last buttons
@@ -61,7 +64,7 @@ var bootstrapWizardCreate = function(element, options) {
 		$index = obj.nextIndex();
 		if($index > obj.navigationLength()) {
 		} else {
-			$navigation.find('li:eq('+$index+') a').tab('show');
+			$navigation.find(baseItemSelector + ':eq('+$index+') a').tab('show');
 		}
 	};
 
@@ -79,7 +82,7 @@ var bootstrapWizardCreate = function(element, options) {
 		$index = obj.previousIndex();
 		if($index < 0) {
 		} else {
-			$navigation.find('li:eq('+$index+') a').tab('show');
+			$navigation.find(baseItemSelector + ':eq('+$index+') a').tab('show');
 		}
 	};
 
@@ -92,7 +95,7 @@ var bootstrapWizardCreate = function(element, options) {
 		if(element.hasClass('disabled')) {
 			return false;
 		}
-		$navigation.find('li:eq(0) a').tab('show');
+		$navigation.find(baseItemSelector + ':eq(0) a').tab('show');
 
 	};
 	this.last = function(e) {
@@ -104,10 +107,10 @@ var bootstrapWizardCreate = function(element, options) {
 		if(element.hasClass('disabled')) {
 			return false;
 		}
-		$navigation.find('li:eq('+obj.navigationLength()+') a').tab('show');
+		$navigation.find(baseItemSelector + ':eq('+obj.navigationLength()+') a').tab('show');
 	};
 	this.currentIndex = function() {
-		return $navigation.find('li').index($activeTab);
+		return $navigation.find(baseItemSelector).index($activeTab);
 	};
 	this.firstIndex = function() {
 		return 0;
@@ -116,48 +119,48 @@ var bootstrapWizardCreate = function(element, options) {
 		return obj.navigationLength();
 	};
 	this.getIndex = function(e) {
-		return $navigation.find('li').index(e);
+		return $navigation.find(baseItemSelector).index(e);
 	};
 	this.nextIndex = function() {
-		return $navigation.find('li').index($activeTab) + 1;
+		return $navigation.find(baseItemSelector).index($activeTab) + 1;
 	};
 	this.previousIndex = function() {
-		return $navigation.find('li').index($activeTab) - 1;
+		return $navigation.find(baseItemSelector).index($activeTab) - 1;
 	};
 	this.navigationLength = function() {
-		return $navigation.find('li').length - 1;
+		return $navigation.find(baseItemSelector).length - 1;
 	};
 	this.activeTab = function() {
 		return $activeTab;
 	};
 	this.nextTab = function() {
-		return $navigation.find('li:eq('+(obj.currentIndex()+1)+')').length ? $navigation.find('li:eq('+(obj.currentIndex()+1)+')') : null;
+		return $navigation.find(baseItemSelector + ':eq('+(obj.currentIndex()+1)+')').length ? $navigation.find(baseItemSelector + ':eq('+(obj.currentIndex()+1)+')') : null;
 	};
 	this.previousTab = function() {
 		if(obj.currentIndex() <= 0) {
 			return null;
 		}
-		return $navigation.find('li:eq('+parseInt(obj.currentIndex()-1)+')');
+		return $navigation.find(baseItemSelector + ':eq('+parseInt(obj.currentIndex()-1)+')');
 	};
 	this.show = function(index) {
-		return element.find('li:eq(' + index + ') a').tab('show');
+		return element.find(baseItemSelector + ':eq(' + index + ') a').tab('show');
 	};
 	this.disable = function(index) {
-		$navigation.find('li:eq('+index+')').addClass('disabled');
+		$navigation.find(baseItemSelector + ':eq('+index+')').addClass('disabled');
 	};
 	this.enable = function(index) {
-		$navigation.find('li:eq('+index+')').removeClass('disabled');
+		$navigation.find(baseItemSelector + ':eq('+index+')').removeClass('disabled');
 	};
 	this.hide = function(index) {
-		$navigation.find('li:eq('+index+')').hide();
+		$navigation.find(baseItemSelector + ':eq('+index+')').hide();
 	};
 	this.display = function(index) {
-		$navigation.find('li:eq('+index+')').show();
+		$navigation.find(baseItemSelector + ':eq('+index+')').show();
 	};
 	this.remove = function(args) {
 		var $index = args[0];
 		var $removeTabPane = typeof args[1] != 'undefined' ? args[1] : false;
-		var $item = $navigation.find('li:eq('+$index+')');
+		var $item = $navigation.find(baseItemSelector + ':eq('+$index+')');
 
 		// Remove the tab pane first if needed
 		if($removeTabPane) {
@@ -170,7 +173,7 @@ var bootstrapWizardCreate = function(element, options) {
 	};
 
 	$navigation = element.find('ul:first', element);
-	$activeTab = $navigation.find('li.active', element);
+	$activeTab = $navigation.find(baseItemSelector + '.active', element);
 
 	if(!$navigation.hasClass($settings.tabClass)) {
 		$navigation.addClass($settings.tabClass);
@@ -191,7 +194,7 @@ var bootstrapWizardCreate = function(element, options) {
 
 	$('a[data-toggle="tab"]', $navigation).on('click', function (e) {
 		// Get the index of the clicked tab
-		var clickedIndex = $navigation.find('li').index($(e.currentTarget).parent('li'));
+		var clickedIndex = $navigation.find(baseItemSelector).index($(e.currentTarget).parent(baseItemSelector));
 		if($settings.onTabClick && typeof $settings.onTabClick === 'function' && $settings.onTabClick($activeTab, $navigation, obj.currentIndex(), clickedIndex)===false){
 			return false;
 		}
@@ -199,7 +202,7 @@ var bootstrapWizardCreate = function(element, options) {
 
 	$('a[data-toggle="tab"]', $navigation).on('shown', function (e) {  // use shown instead of show to help prevent double firing
 		$element = $(e.target).parent();
-		var nextTab = $navigation.find('li').index($element);
+		var nextTab = $navigation.find(baseItemSelector).index($element);
 
 		// If it's disabled then do not change
 		if($element.hasClass('disabled')) {


### PR DESCRIPTION
Potential fix for issue #33.  Created a 'baseItemSelector' that only
selected items with have a child with the 'data-toggle' attribute set
to "tab" and used that when referencing tabs.
