### PR TITLE
Skipping steps

### DIFF
--- a/jquery.bootstrap.wizard.js
+++ b/jquery.bootstrap.wizard.js
@@ -13,7 +13,7 @@
 var bootstrapWizardCreate = function(element, options) {
 	var element = $(element);
 	var obj = this;
-	
+
 	// selector skips any 'li' elements that do not contain a child with a tab data-toggle
 	var baseItemSelector = 'li:has([data-toggle="tab"])';
 	var historyStack = [];
@@ -22,7 +22,7 @@ var bootstrapWizardCreate = function(element, options) {
 	var $settings = $.extend({}, $.fn.bootstrapWizard.defaults, options);
 	var $activeTab = null;
 	var $navigation = null;
-	
+
 	this.rebindClick = function(selector, fn)
 	{
 		selector.unbind('click', fn).bind('click', fn);
@@ -75,7 +75,7 @@ var bootstrapWizardCreate = function(element, options) {
 		if($index > obj.navigationLength()) {
 		} else {
 		  historyStack.push(formerIndex);
-		  $navigation.find(baseItemSelector + ':eq(' + $index + ') a').tab('show');
+		  $navigation.find(baseItemSelector + ':visible:eq(' + $index + ') a').tab('show');
 		}
 	};
 
@@ -95,7 +95,7 @@ var bootstrapWizardCreate = function(element, options) {
 		if($index < 0) {
 		} else {
 		  historyStack.push(formerIndex);
-		  $navigation.find(baseItemSelector + ':eq(' + $index + ') a').tab('show');
+		  $navigation.find(baseItemSelector + ':visible:eq(' + $index + ') a').tab('show');
 		}
 	};
 
@@ -183,8 +183,8 @@ var bootstrapWizardCreate = function(element, options) {
 		return $navigation.find(baseItemSelector + ':eq('+parseInt(obj.currentIndex()-1)+')');
 	};
 	this.show = function(index) {
-	  var tabToShow = isNaN(index) ? 
-      element.find(baseItemSelector + ' a[href=#' + index + ']') : 
+	  var tabToShow = isNaN(index) ?
+      element.find(baseItemSelector + ' a[href=#' + index + ']') :
       element.find(baseItemSelector + ':eq(' + index + ') a');
 	  if (tabToShow.length > 0) {
 	    historyStack.push(obj.currentIndex());
@@ -217,7 +217,7 @@ var bootstrapWizardCreate = function(element, options) {
 		// Remove menu item
 		$item.remove();
 	};
-	
+
 	var innerTabClick = function (e) {
 		// Get the index of the clicked tab
 		var $ul = $navigation.find(baseItemSelector);
@@ -227,7 +227,7 @@ var bootstrapWizardCreate = function(element, options) {
 		    return false;
 		}
 	};
-	
+
 	var innerTabShown = function (e) {  // use shown instead of show to help prevent double firing
 		$element = $(e.target).parent();
 		var nextTab = $navigation.find(baseItemSelector).index($element);
@@ -244,21 +244,21 @@ var bootstrapWizardCreate = function(element, options) {
 		$activeTab = $element; // activated tab
 		obj.fixNavigationButtons();
 	};
-	
+
 	this.resetWizard = function() {
-		
+
 		// remove the existing handlers
 		$('a[data-toggle="tab"]', $navigation).off('click', innerTabClick);
 		$('a[data-toggle="tab"]', $navigation).off('shown shown.bs.tab', innerTabShown);
-		
+
 		// reset elements based on current state of the DOM
 		$navigation = element.find('ul:first', element);
 		$activeTab = $navigation.find(baseItemSelector + '.active', element);
-		
+
 		// re-add handlers
 		$('a[data-toggle="tab"]', $navigation).on('click', innerTabClick);
 		$('a[data-toggle="tab"]', $navigation).on('shown shown.bs.tab', innerTabShown);
-		
+
 		obj.fixNavigationButtons();
 	};
 
@@ -323,7 +323,7 @@ $.fn.bootstrapWizard.defaults = {
 	onFirst:          null,
   onFinish:         null,
   onBack:           null,
-	onTabChange:      null, 
+	onTabChange:      null,
 	onTabClick:       null,
 	onTabShow:        null
 };


### PR DESCRIPTION
When I would hide the step and press next, the step would still show up. The `:visible` will make sure the right index is picked.

```
$wizard.bootstrapWizard('hide', index);
```