### PR TITLE
Updated find to use non-visible element steps

### DIFF
--- a/jquery.bootstrap.wizard.js
+++ b/jquery.bootstrap.wizard.js
@@ -75,7 +75,7 @@ var bootstrapWizardCreate = function(element, options) {
 		if($index > obj.navigationLength()) {
 		} else {
 		  historyStack.push(formerIndex);
-		  $navigation.find(baseItemSelector + ':visible:eq(' + $index + ') a').tab('show');
+		  $navigation.find(baseItemSelector + ':eq(' + $index + ') a').tab('show');
 		}
 	};
 
@@ -95,7 +95,7 @@ var bootstrapWizardCreate = function(element, options) {
 		if($index < 0) {
 		} else {
 		  historyStack.push(formerIndex);
-		  $navigation.find(baseItemSelector + ':visible:eq(' + $index + ') a').tab('show');
+		  $navigation.find(baseItemSelector + ':eq(' + $index + ') a').tab('show');
 		}
 	};
 


### PR DESCRIPTION
My company wishes to have a form wizard but have the steps display hidden on mobile displays.

However, because of the `:visible` selector, the next and the previous buttons do not work, as the steps display is not visible.

This change will enable the next and previous buttons to work even if the step displays are not visible.

I'm not sure why `:visible` was included in the original implementation, so feel free to discuss this PR if it needs to be changed.

I believe issue #131 is related to this PR.