### PR TITLE
fix of issue 167

### DIFF
--- a/jquery.bootstrap.wizard.js
+++ b/jquery.bootstrap.wizard.js
@@ -228,7 +228,7 @@ var bootstrapWizardCreate = function(element, options) {
 		}
 	};
 
-	var innerTabShown = function (e) {  // use shown instead of show to help prevent double firing
+	var innerTabShown = function (e) {  
 		var $element = $(e.target).parent();
 		var nextTab = $navigation.find(baseItemSelector).index($element);
 
@@ -249,7 +249,7 @@ var bootstrapWizardCreate = function(element, options) {
 
 		// remove the existing handlers
 		$('a[data-toggle="tab"]', $navigation).off('click', innerTabClick);
-		$('a[data-toggle="tab"]', $navigation).off('shown shown.bs.tab', innerTabShown);
+		$('a[data-toggle="tab"]', $navigation).off('show show.bs.tab', innerTabShown);
 
 		// reset elements based on current state of the DOM
 		$navigation = element.find('ul:first', element);
@@ -257,7 +257,7 @@ var bootstrapWizardCreate = function(element, options) {
 
 		// re-add handlers
 		$('a[data-toggle="tab"]', $navigation).on('click', innerTabClick);
-		$('a[data-toggle="tab"]', $navigation).on('shown shown.bs.tab', innerTabShown);
+		$('a[data-toggle="tab"]', $navigation).on('show show.bs.tab', innerTabShown);
 
 		obj.fixNavigationButtons();
 	};
@@ -281,8 +281,8 @@ var bootstrapWizardCreate = function(element, options) {
 
 	$('a[data-toggle="tab"]', $navigation).on('click', innerTabClick);
 
-	// attach to both shown and shown.bs.tab to support Bootstrap versions 2.3.2 and 3.0.0
-	$('a[data-toggle="tab"]', $navigation).on('shown shown.bs.tab', innerTabShown);
+	// attach to both show and show.bs.tab to support Bootstrap versions 2.3.2 and 3.0.0
+	$('a[data-toggle="tab"]', $navigation).on('show show.bs.tab', innerTabShown);
 };
 $.fn.bootstrapWizard = function(options) {
 	//expose methods


### PR DESCRIPTION
The "shown" event will be fired after the tab has already displayed, so all false return values will be ignored, causing https://github.com/VinceG/twitter-bootstrap-wizard/issues/167 (e.g. a click on a disabled tab will still show it): The fix is to indeed use the show instead of the shown event.